### PR TITLE
fix exit status

### DIFF
--- a/script/liveman
+++ b/script/liveman
@@ -40,7 +40,7 @@ elsif($project) {
 elsif($append) {
     require Liveman::Append;
     my $liveman = Liveman::Append->new(files => \@ARGV)->appends;
-    exit $liveman->{count} > 0? 0: 1;
+    exit($liveman->{count} > 0 ? 0 : 1);
 }
 else {
     my $liveman = Liveman->new(


### PR DESCRIPTION
`exit` has higher precedence than `?:` and `>`, so `exit $count > 0 ? 0 : 1` parses as `(exit $count) > 0 ? 0 : 1`, which is not what was intended.